### PR TITLE
configure.ac: Don't override -mfpu when NEON-capable FPU is already set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,12 @@ elif test "$enable_neon" = "yes" ; then
      AC_DEFINE(DVBCSA_USE_NEON, 1, Using NEON bitslice.)
      case $host_cpu in
          arm64*|aarch64*) ;;
-         arm*) GCC_CFLAGS="$GCC_CFLAGS -mfpu=neon" ;;
+         arm*)
+             case "$GCC_CFLAGS" in
+                 *-mfpu=*neon*) ;;
+                 *) GCC_CFLAGS="$GCC_CFLAGS -mfpu=neon" ;;
+             esac
+             ;;
      esac
 
 elif test "$enable_uint32" = "yes" ; then


### PR DESCRIPTION
When cross-compiling with build systems like Yocto/OE, the environment typically provides a more specific -mfpu flag (e.g. -mfpu=neon-vfpv4) via CFLAGS. The unconditional -mfpu=neon appended by configure would override this since GCC uses the last -mfpu flag, effectively downgrading the FPU configuration.

Check GCC_CFLAGS (which inherits the original CFLAGS) for an existing NEON-capable -mfpu setting before adding -mfpu=neon. This preserves the correct FPU configuration from build systems while still adding -mfpu=neon for standalone builds where no such flag is present.