### PR TITLE
configure.ac: Also check CC variable for existing NEON -mfpu flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ elif test "$enable_neon" = "yes" ; then
      case $host_cpu in
          arm64*|aarch64*) ;;
          arm*)
-             case "$GCC_CFLAGS" in
+             case "$CC $GCC_CFLAGS" in
                  *-mfpu=*neon*) ;;
                  *) GCC_CFLAGS="$GCC_CFLAGS -mfpu=neon" ;;
              esac


### PR DESCRIPTION
Yocto/OE embeds TUNE_CCARGS (including -mfpu=neon-vfpv4) in the CC variable rather than CFLAGS. The previous check only looked at GCC_CFLAGS (derived from CFLAGS) and missed the flag in CC, so -mfpu=neon was still being appended and overriding the more specific -mfpu=neon-vfpv4 from the build system.

Check both CC and GCC_CFLAGS to cover all cross-compilation setups.