### PR TITLE
Reduce code duplication without sacrificing performance

### DIFF
--- a/src/dvbcsa_bs_stream.c
+++ b/src/dvbcsa_bs_stream.c
@@ -27,9 +27,6 @@
 #include "dvbcsa_bs.h"
 #include "dvbcsa_bs_stream_kernel.h"
 
-#define DVBCSA_BS_STREAM_KERNEL_INIT 
-#include "dvbcsa_bs_stream_kernel.inc"
-#undef DVBCSA_BS_STREAM_KERNEL_INIT 
 #include "dvbcsa_bs_stream_kernel.inc"
 
 void

--- a/src/dvbcsa_bs_stream_kernel.h
+++ b/src/dvbcsa_bs_stream_kernel.h
@@ -18,5 +18,8 @@ struct dvbcsa_bs_stream_regs_s {
   dvbcsa_bs_word_t r;
 };
 
+#define dvbcsa_bs_stream_cipher_kernel_init(regs)    _dvbcsa_bs_stream_cipher_kernel(1, regs)
+#define dvbcsa_bs_stream_cipher_kernel(regs)         _dvbcsa_bs_stream_cipher_kernel(0, regs)
+
 #endif
 

--- a/src/dvbcsa_bs_stream_kernel.inc
+++ b/src/dvbcsa_bs_stream_kernel.inc
@@ -1,5 +1,3 @@
-#ifdef DVBCSA_BS_STREAM_KERNEL_INIT
-
 static void DVBCSA_INLINE inline
 dvbcsa_bs_stream_sbox1(dvbcsa_bs_word_t fa, dvbcsa_bs_word_t fb,
                        dvbcsa_bs_word_t fc, dvbcsa_bs_word_t fd,
@@ -117,16 +115,8 @@ dvbcsa_bs_stream_sbox7(dvbcsa_bs_word_t fa, dvbcsa_bs_word_t fb,
   *sb = BS_XOR (tmp2, BS_AND (fe, tmp3));
 }
 
-static void
-dvbcsa_bs_stream_cipher_kernel_init(struct dvbcsa_bs_stream_regs_s *regs)
-
-#else
-
-static void
-dvbcsa_bs_stream_cipher_kernel(struct dvbcsa_bs_stream_regs_s *regs)
-
-#endif
-
+static void DVBCSA_INLINE inline
+_dvbcsa_bs_stream_cipher_kernel(const int init, struct dvbcsa_bs_stream_regs_s *regs)
 {
   dvbcsa_bs_word_t extra_B[4];
   dvbcsa_bs_word_t (*A)[4], (*B)[4];
@@ -151,10 +141,8 @@ dvbcsa_bs_stream_cipher_kernel(struct dvbcsa_bs_stream_regs_s *regs)
           for (b = 0; b < 4; b++)
             {
               A[-1][b] = BS_XOR (A[9][b], regs->X[b]);
-#ifdef DVBCSA_BS_STREAM_KERNEL_INIT
-              //A[-1][b] = BS_XOR (BS_XOR (A[-1][b], D[b]), ((j % 2) ? in2[b] : in1[b]));
-              A[-1][b] = BS_XOR (BS_XOR (A[-1][b], regs->D[b]), ((j % 2) ? regs->sb[8 * i + b] : regs->sb[8 * i + 4 + b]));
-#endif
+              if (init)
+                A[-1][b] = BS_XOR (BS_XOR (A[-1][b], regs->D[b]), ((j % 2) ? regs->sb[8 * i + b] : regs->sb[8 * i + 4 + b]));
             }
 
           // T2 =  xor all inputs
@@ -163,10 +151,8 @@ dvbcsa_bs_stream_cipher_kernel(struct dvbcsa_bs_stream_regs_s *regs)
           for (b = 0; b < 4; b++)
             {
               B[-1][b] = BS_XOR (BS_XOR (B[6][b], B[9][b]), regs->Y[b]);
-#ifdef DVBCSA_BS_STREAM_KERNEL_INIT
-              //B[-1][b] = BS_XOR (B[-1][b], ((j % 2) ? in1[b] : in2[b]));
-              B[-1][b] = BS_XOR (B[-1][b], ((j % 2) ? regs->sb[8 * i + 4 + b]: regs->sb[8 * i + b]));
-#endif
+              if (init)
+                B[-1][b] = BS_XOR (B[-1][b], ((j % 2) ? regs->sb[8 * i + 4 + b]: regs->sb[8 * i + b]));
             }
 
           // if p=1, rotate left (yes, this is what we're doing)
@@ -239,15 +225,14 @@ dvbcsa_bs_stream_cipher_kernel(struct dvbcsa_bs_stream_regs_s *regs)
           A--;
           B--;
 
-#ifndef DVBCSA_BS_STREAM_KERNEL_INIT
-
-          // require 4 loops per output byte
-          // 2 output bits are a function of the 4 bits of D
-          // xor 2 by 2
-          regs->sb[i * 8 + 7 - 2 * j] = BS_XOR (regs->D[2], regs->D[3]);
-          regs->sb[i * 8 + 6 - 2 * j] = BS_XOR (regs->D[0], regs->D[1]);
-
-#endif
+          if (!init)
+            {
+              // require 4 loops per output byte
+              // 2 output bits are a function of the 4 bits of D
+              // xor 2 by 2
+              regs->sb[i * 8 + 7 - 2 * j] = BS_XOR (regs->D[2], regs->D[3]);
+              regs->sb[i * 8 + 6 - 2 * j] = BS_XOR (regs->D[0], regs->D[1]);
+            }
         }  // INTERNAL LOOP
     }   // EXTERNAL LOOP
 

--- a/src/dvbcsa_key.c
+++ b/src/dvbcsa_key.c
@@ -571,21 +571,6 @@ static inline uint64_t dvbcsa_key_permute_block(uint64_t k)
 }
 
 void
-dvbcsa_key_schedule_block(const dvbcsa_cw_t cw, uint8_t * kk)
-{
-  uint64_t k[7];
-  int i, j;
-
-  k[6] = dvbcsa_load_le64(cw);
-  for (i = 6; i > 0; i--)
-    k[i - 1] = dvbcsa_key_permute_block(k[i]);
-
-  for (i = 0; i < 7; i++)
-    for (j = 0; j < 8; j++)
-      kk[i*8+j] = (k[i]>>(j*8)) ^ i;
-}
-
-void
 dvbcsa_key_schedule_block_ecm(const unsigned char ecm, const dvbcsa_cw_t cw, uint8_t * kk)
 {
   uint64_t k[7];
@@ -598,4 +583,10 @@ dvbcsa_key_schedule_block_ecm(const unsigned char ecm, const dvbcsa_cw_t cw, uin
   for (i = 0; i < 7; i++)
     for (j = 0; j < 8; j++)
       kk[i*8+j] = (k[i]>>(j*8)) ^ i;
+}
+
+void
+dvbcsa_key_schedule_block(const dvbcsa_cw_t cw, uint8_t * kk)
+{
+  dvbcsa_key_schedule_block_ecm(0, cw, kk);
 }

--- a/src/dvbcsa_pv.h
+++ b/src/dvbcsa_pv.h
@@ -141,25 +141,7 @@ dvbcsa_load_le32(const uint8_t *p)
 #endif
 }
 
-DVBCSA_INLINE static inline uint64_t
-dvbcsa_load_le64(const uint8_t *p)
-{
-#if defined(DVBCSA_ENDIAN_LITTLE)
-  uint64_t i;
-  memcpy(&i, p, 8);
-  return i;
-#else
-  return (uint64_t)( ((uint64_t)p[7] << 56) |
-                     ((uint64_t)p[6] << 48) |
-                     ((uint64_t)p[5] << 40) |
-                     ((uint64_t)p[4] << 32) |
-                     ((uint64_t)p[3] << 24) |
-                     ((uint64_t)p[2] << 16) |
-                     ((uint64_t)p[1] << 8 ) |
-                      (uint64_t)p[0]
-                     );
-#endif
-}
+#define dvbcsa_load_le64(p)    dvbcsa_load_le64_ecm(0, p)
 
 DVBCSA_INLINE static inline uint64_t
 dvbcsa_load_le64_ecm(const unsigned char ecm, const uint8_t *p)


### PR DESCRIPTION
Inspired by PR #4 (lukasz1992), this commit eliminates duplicated code across the stream cipher kernel and key scheduling functions while preserving the original runtime performance characteristics.

Stream cipher kernel (dvbcsa_bs_stream_kernel.inc):
- Replace the #ifdef DVBCSA_BS_STREAM_KERNEL_INIT / #else / #endif double-include trick with a single unified function _dvbcsa_bs_stream_cipher_kernel(const int init, regs).
- The function is marked static DVBCSA_INLINE inline, which maps to __attribute__((always_inline)) on GCC. Combined with the macro wrappers that pass literal constants (0 or 1), the compiler is guaranteed to inline and eliminate the dead branches via constant propagation — producing identical machine code to the original two-function approach.
- The sbox0 computation (4x unrolled Z/E carry chain) is intentionally kept unrolled. Extracting it into a loop function would break the regs->r "ultimate carry" calculation, which depends on tmp1/tmp3 values from the final iteration remaining in scope.

Stream cipher includes (dvbcsa_bs_stream.c):
- The .inc file is now included only once instead of the previous define/undef/include-twice pattern.

Kernel dispatch macros (dvbcsa_bs_stream_kernel.h):
- dvbcsa_bs_stream_cipher_kernel_init(regs) and dvbcsa_bs_stream_cipher_kernel(regs) are now macros that call _dvbcsa_bs_stream_cipher_kernel with compile-time constant 1 or 0.

Key scheduling (dvbcsa_key.c):
- dvbcsa_key_schedule_block() now delegates to dvbcsa_key_schedule_block_ecm(0, cw, kk), removing the duplicated loop body.

Little-endian load (dvbcsa_pv.h):
- dvbcsa_load_le64(p) is now a macro expanding to dvbcsa_load_le64_ecm(0, p). The compiler sees ecm=0 != 4 at compile time and eliminates the csa_block_perm_ecm lookup path entirely.